### PR TITLE
Websocket Changes

### DIFF
--- a/Fuyu.Backend.EFT/Controllers/PushNotiferGetWebsocketController.cs
+++ b/Fuyu.Backend.EFT/Controllers/PushNotiferGetWebsocketController.cs
@@ -1,0 +1,23 @@
+﻿using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Fuyu.Common.Networking;
+
+namespace Fuyu.Backend.EFT.Controllers
+{
+	public partial class PushNotiferGetWebsocketController : WsController
+	{
+		public PushNotiferGetWebsocketController() : base(PathExpression())
+		{
+		}
+
+		// NOTE: No event registrations as I am not implementing anything
+		// -- nexus4880, 2024-10-23
+		public override Task RunAsync(WsContext context)
+		{
+			return Task.CompletedTask;
+		}
+
+		[GeneratedRegex("^/push/notifier/getwebsocket/(?<channelId>[A-Za-z0-9]+)$")]
+		private static partial Regex PathExpression();
+	}
+}

--- a/Fuyu.Backend.EFT/Servers/EftMainServer.cs
+++ b/Fuyu.Backend.EFT/Servers/EftMainServer.cs
@@ -14,6 +14,7 @@ namespace Fuyu.Backend.EFT.Servers
             // Custom
             HttpRouter.AddController<FuyuGameLoginController>();
             HttpRouter.AddController<FuyuGameRegisterController>();
+
             // EFT
             HttpRouter.AddController<AccountCustomizationController>();
             HttpRouter.AddController<AchievementListController>();
@@ -69,6 +70,9 @@ namespace Fuyu.Backend.EFT.Servers
             HttpRouter.AddController<SurveyController>();
             HttpRouter.AddController<TraderSettingsController>();
             HttpRouter.AddController<WeatherController>();
+
+            // EFT WS
+            WsRouter.AddController<PushNotiferGetWebsocketController>();
         }
     }
 }

--- a/Fuyu.Common/Networking/HttpServer.cs
+++ b/Fuyu.Common/Networking/HttpServer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -82,10 +83,8 @@ namespace Fuyu.Common.Networking
             try
             {
                 var context = new WsContext(listenerContext.Request, listenerContext.Response, ws);
-
                 var time = DateTime.UtcNow.ToString();
                 Terminal.WriteLine($"[{time}][{Name}][WS  ] {context.Path}");
-
                 await WsRouter.RouteAsync(context);
             }
             catch (Exception ex)

--- a/Fuyu.Common/Networking/WsContext.cs
+++ b/Fuyu.Common/Networking/WsContext.cs
@@ -12,9 +12,13 @@ namespace Fuyu.Common.Networking
         private const int _bufferSize = 32000;
         private readonly WebSocket _ws;
 
-        public Func<WsContext, Task> OnCloseAsync;
-        public Func<WsContext, string, Task> OnTextAsync;
-        public Func<WsContext, byte[], Task> OnBinaryAsync;
+        public delegate Task OnTextEventHandler(WsContext sender, string text);
+        public delegate Task OnBinaryEventHandler(WsContext sender, byte[] binary);
+        public delegate Task OnCloseEventHandler(WsContext sender);
+
+        public event OnTextEventHandler OnTextEvent;
+        public event OnBinaryEventHandler OnBinaryEvent;
+        public event OnCloseEventHandler OnCloseEvent;
 
         public WsContext(HttpListenerRequest request, HttpListenerResponse response, WebSocket ws) : base(request, response)
         {
@@ -26,32 +30,43 @@ namespace Fuyu.Common.Networking
             return _ws.State == WebSocketState.Open;
         }
 
-        // TODO:
-        // * use System.Buffers.ArrayPool for receiveBuffer
-        // -- seionmoya, 2024/09/09
-        public async Task ReceiveAsync()
+		// TODO:
+		// * use System.Buffers.ArrayPool for receiveBuffer
+		// -- seionmoya, 2024/09/09
+
+		// NOTE: Made this internal because consumers
+		// shouldn't be calling this on their own
+        // -- nexus4880, 2024-10-23
+		internal async Task PollAsync()
         {
             var buffer = new byte[_bufferSize];
-            var received = await _ws.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+			var received = await _ws.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
             var data = new byte[received.Count];
             Array.Copy(buffer, 0, data, 0, data.Length);
 
             switch (received.MessageType)
             {
-                case WebSocketMessageType.Close:
-                    await OnCloseAsync(this);
-                    await CloseAsync();
-                    break;
-
                 case WebSocketMessageType.Text:
                     var text = Encoding.UTF8.GetString(data);
-                    await OnTextAsync(this, text);
+                    if (OnTextEvent != null)
+					{
+						await OnTextEvent(this, text);
+					}
+
                     break;
 
                 case WebSocketMessageType.Binary:
-                    await OnBinaryAsync(this, data);
+                    if (OnBinaryEvent != null)
+                    {
+                        await OnBinaryEvent(this, data);
+					}
+
                     break;
-            }
+
+				case WebSocketMessageType.Close:
+					await CloseAsync();
+					break;
+			}
         }
 
         public async Task SendTextAsync(string text)
@@ -70,6 +85,10 @@ namespace Fuyu.Common.Networking
         public async Task CloseAsync()
         {
             await _ws.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
+            if (OnCloseEvent != null)
+            {
+                await OnCloseEvent(this);
+			}
         }
     }
 }

--- a/Fuyu.Common/Networking/WsController.cs
+++ b/Fuyu.Common/Networking/WsController.cs
@@ -15,10 +15,14 @@ namespace Fuyu.Common.Networking
   			// match static paths
 		}
 
-		public virtual Task OnConnectAsync(WsContext context)
-        {
+		public override Task RunAsync(WsContext context)
+		{
+			context.OnCloseEvent += OnCloseAsync;
+			context.OnTextEvent += OnTextAsync;
+			context.OnBinaryEvent += OnBinaryAsync;
+
             return Task.CompletedTask;
-        }
+		}
 
         public virtual Task OnCloseAsync(WsContext context)
         {
@@ -33,14 +37,6 @@ namespace Fuyu.Common.Networking
         public virtual Task OnBinaryAsync(WsContext context, byte[] binary)
         {
             return Task.CompletedTask;
-        }
-
-        public async Task InitializeAsync(WsContext context)
-        {
-            context.OnCloseAsync = OnCloseAsync;
-            context.OnTextAsync = OnTextAsync;
-            context.OnBinaryAsync = OnBinaryAsync;
-            await OnConnectAsync(context);
         }
 	}
 }


### PR DESCRIPTION
### Problem 1
Websocket connections could not poll to see if the connection was terminated by the client unless `ReceiveAsync` was called.

- Each `WsController`, if utilizing `while (context.IsOpen())` would need to call `ReceiveAsync`
- If we want to match multiple controllers to a route in the future, only the first one would work

Solution: Move the burden of calling `ReceiveAsync` from the `WsController` to the `WsRouter`. It has been made `internal` and renamed to `PollAsync` so as not to be confused: it should **NOT** be called outside of `WsRouter`.

This places the responsibility of maintaining and managing the connection on the `WsRouter` instead of the `WsController`s. This approach is also eh. In hindsight the `HttpServer` may have been best off owning and managing the state of the `WsContext` but it shouldn't be that big of a deal.
___
### Problem 2
Because we are not fire and forgetting the controller's handle functions if a `WsController` runs a while loop for constant polling to check for data then the `WsRouter` will never continue.

Solution: Move to an event based system. The `WsContext` calls `WsController.RunAsync` which subscribes its callbacks to `WsContext`'s events. This allows for us to override `WsController.RunAsync` in order to subscribe to only events that we need. By default all of them are subscribed.
___

I have done testing in and outside of the game, as well as making it so that I can relay notifications to my client from Postman. It is working exactly as I expected.