### PR TITLE
Rework httpcontext

### DIFF
--- a/Fuyu.Backend.Core/Controllers/AccountGamesController.cs
+++ b/Fuyu.Backend.Core/Controllers/AccountGamesController.cs
@@ -1,18 +1,18 @@
 ﻿using System.Threading.Tasks;
 using Fuyu.Backend.Core.Models.Responses;
+using Fuyu.Backend.Core.Networking;
 using Fuyu.Backend.Core.Services;
-using Fuyu.Common.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.Core.Controllers
 {
-    public class AccountGamesController : HttpController
+    public class AccountGamesController : CoreHttpController
     {
         public AccountGamesController() : base("/account/games")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(CoreHttpContext context)
         {
             var sessionId = context.GetSessionId();
             var result = AccountService.GetGames(sessionId);

--- a/Fuyu.Backend.Core/Controllers/AccountLoginController.cs
+++ b/Fuyu.Backend.Core/Controllers/AccountLoginController.cs
@@ -1,18 +1,18 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.Core.Models.Requests;
+using Fuyu.Backend.Core.Networking;
 using Fuyu.Backend.Core.Services;
-using Fuyu.Common.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.Core.Controllers
 {
-    public class AccountLoginController : HttpController<AccountLoginRequest>
+    public class AccountLoginController : CoreHttpController<AccountLoginRequest>
     {
         public AccountLoginController() : base("/account/login")
         {
         }
 
-        public override Task RunAsync(HttpContext context, AccountLoginRequest body)
+        public override Task RunAsync(CoreHttpContext context, AccountLoginRequest body)
         {
             var response = AccountService.LoginAccount(body.Username, body.Password);
 

--- a/Fuyu.Backend.Core/Controllers/AccountLogoutController.cs
+++ b/Fuyu.Backend.Core/Controllers/AccountLogoutController.cs
@@ -1,15 +1,15 @@
 ﻿using System.Threading.Tasks;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.Core.Networking;
 
 namespace Fuyu.Backend.Core.Controllers
 {
-    public class AccountLogoutController : HttpController
+    public class AccountLogoutController : CoreHttpController
     {
         public AccountLogoutController() : base("/account/logout")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(CoreHttpContext context)
         {
             var sessionId = context.GetSessionId();
             CoreOrm.RemoveSession(sessionId);

--- a/Fuyu.Backend.Core/Controllers/AccountRegisterController.cs
+++ b/Fuyu.Backend.Core/Controllers/AccountRegisterController.cs
@@ -1,19 +1,19 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.Core.Models.Requests;
 using Fuyu.Backend.Core.Models.Responses;
+using Fuyu.Backend.Core.Networking;
 using Fuyu.Backend.Core.Services;
-using Fuyu.Common.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.Core.Controllers
 {
-    public class AccountRegisterController : HttpController<AccountRegisterRequest>
+    public class AccountRegisterController : CoreHttpController<AccountRegisterRequest>
     {
         public AccountRegisterController() : base("/account/register")
         {
         }
 
-        public override Task RunAsync(HttpContext context, AccountRegisterRequest request)
+        public override Task RunAsync(CoreHttpContext context, AccountRegisterRequest request)
         {
             var result = AccountService.RegisterAccount(request.Username, request.Password);
             var response = new AccountRegisterResponse()

--- a/Fuyu.Backend.Core/Controllers/AccountRegisterGameController.cs
+++ b/Fuyu.Backend.Core/Controllers/AccountRegisterGameController.cs
@@ -1,18 +1,18 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.Core.Models.Requests;
+using Fuyu.Backend.Core.Networking;
 using Fuyu.Backend.Core.Services;
-using Fuyu.Common.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.Core.Controllers
 {
-    public class AccountRegisterGameController : HttpController<AccountRegisterGameRequest>
+    public class AccountRegisterGameController : CoreHttpController<AccountRegisterGameRequest>
     {
         public AccountRegisterGameController() : base("/account/register/game")
         {
         }
 
-        public override Task RunAsync(HttpContext context, AccountRegisterGameRequest request)
+        public override Task RunAsync(CoreHttpContext context, AccountRegisterGameRequest request)
         {
             var sessionId = context.GetSessionId();
             var result = AccountService.RegisterGame(sessionId, request.Game, request.Edition);

--- a/Fuyu.Backend.Core/Networking/CoreHttpContext.cs
+++ b/Fuyu.Backend.Core/Networking/CoreHttpContext.cs
@@ -21,7 +21,7 @@ namespace Fuyu.Backend.Core.Networking
                 var body = ms.ToArray();
                 var encryption = GetEncryption();
 
-                if (encryption != string.Empty)
+                if (!string.IsNullOrWhiteSpace(encryption))
                 {
                     switch (encryption)
                     {

--- a/Fuyu.Backend.Core/Networking/CoreHttpController.cs
+++ b/Fuyu.Backend.Core/Networking/CoreHttpController.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Fuyu.Common.Networking;
+
+namespace Fuyu.Backend.Core.Networking
+{
+    public abstract class CoreHttpController : HttpController
+    {
+        protected CoreHttpController(Regex pattern) : base(pattern)
+        {
+            // match dynamic paths
+        }
+
+        protected CoreHttpController(string path) : base(path)
+        {
+            // match static paths
+        }
+
+        public override Task RunAsync(HttpContext context)
+        {
+            // NOTE: assumes HttpController can be safely downcasted into CoreHttpControler
+            // -- seionmoya, 2024-11-18
+            var downcast = (CoreHttpContext)context;
+
+            return RunAsync(downcast);
+        }
+
+        public abstract Task RunAsync(CoreHttpContext context);
+    }
+
+    public abstract class CoreHttpController<TRequest> : CoreHttpController where TRequest : class
+    {
+        protected CoreHttpController(Regex pattern) : base(pattern)
+        {
+            // match dynamic paths
+        }
+
+        protected CoreHttpController(string path) : base(path)
+        {
+            // match static paths
+        }
+
+        public override Task RunAsync(CoreHttpContext context)
+        {
+            // TODO:
+            // - Use better exception type
+            // -- seionmoya, 2024-10-13
+            if (!context.HasBody())
+            {
+                throw new Exception("Request does not contain body.");
+            }
+
+            var body = context.GetJson<TRequest>();
+
+            // TODO:
+            // - Use better exception type
+            // -- seionmoya, 2024-10-13
+            if (body == null)
+            {
+                throw new Exception("Body could not be parsed as TRequest.");
+            }
+
+            return RunAsync(context, body);
+        }
+
+        public abstract Task RunAsync(CoreHttpContext context, TRequest body);
+    }
+}

--- a/Fuyu.Backend.Core/Networking/CoreHttpController.cs
+++ b/Fuyu.Backend.Core/Networking/CoreHttpController.cs
@@ -19,10 +19,7 @@ namespace Fuyu.Backend.Core.Networking
 
         public override Task RunAsync(HttpContext context)
         {
-            // NOTE: assumes HttpController can be safely downcasted into CoreHttpControler
-            // -- seionmoya, 2024-11-18
-            var downcast = (CoreHttpContext)context;
-
+            var downcast = new CoreHttpContext(context.Request, context.Response);
             return RunAsync(downcast);
         }
 

--- a/Fuyu.Backend.Core/Services/RequestService.cs
+++ b/Fuyu.Backend.Core/Services/RequestService.cs
@@ -19,9 +19,8 @@ namespace Fuyu.Backend.Core.Services
             // TODO:
             // * get address from config
             // -- seionmoya, 2024/09/08
-            _httpClients.Set("fuyu", new EftHttpClient("http://localhost:8000", string.Empty));
-            _httpClients.Set("eft", new EftHttpClient("http://localhost:8010", string.Empty));
-            _httpClients.Set("arena", new EftHttpClient("http://localhost:8020", string.Empty));
+            _httpClients.Set("eft", new HttpClient("http://localhost:8010"));
+            _httpClients.Set("arena", new HttpClient("http://localhost:8020"));
         }
 
         private static T2 HttpPost<T1, T2>(string id, string path, T1 request)
@@ -39,11 +38,6 @@ namespace Fuyu.Backend.Core.Services
             var responseValue = Json.Parse<T2>(responseJson);
 
             return responseValue;
-        }
-
-        public static void CreateSession(string id, string address, string sessionId)
-        {
-            _httpClients.Set(id, new EftHttpClient(address, sessionId));
         }
 
         public static int RegisterGame(string game, string username, string edition)

--- a/Fuyu.Backend.EFT/Controllers/Http/AccountCustomizationController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/AccountCustomizationController.cs
@@ -1,17 +1,20 @@
 using System.Threading.Tasks;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class AccountCustomizationController : HttpController
+    public class AccountCustomizationController : EftHttpController
     {
         public AccountCustomizationController() : base("/client/account/customization")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
-            return context.SendJsonAsync(EftOrm.GetAccountCustomization());
+            // TODO: generate this
+            // --seionmoya, 2024-11-18
+            var text = EftOrm.GetAccountCustomization();
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/AchievementListController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/AchievementListController.cs
@@ -1,17 +1,20 @@
 using System.Threading.Tasks;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class AchievementListController : HttpController
+    public class AchievementListController : EftHttpController
     {
         public AchievementListController() : base("/client/achievement/list")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
-            return context.SendJsonAsync(EftOrm.GetAchievementList());
+            // TODO: generate this
+            // --seionmoya, 2024-11-18
+            var text = EftOrm.GetAchievementList();
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/AchievementStatisticController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/AchievementStatisticController.cs
@@ -1,21 +1,25 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class AchievementStatisticController : HttpController
+    public class AchievementStatisticController : EftHttpController
     {
         public AchievementStatisticController() : base("/client/achievement/statistic")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
+            // TODO: generate this
+            // --seionmoya, 2024-11-18
             var json = EftOrm.GetAchievementStatistic();
             var response = Json.Parse<ResponseBody<AchievementStatisticResponse>>(json);
-            return context.SendJsonAsync(Json.Stringify(response));
+
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/BuildsListController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/BuildsListController.cs
@@ -1,12 +1,12 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.IO;
-using Fuyu.Common.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class BuildsListController : HttpController
+    public class BuildsListController : EftHttpController
     {
         private readonly ResponseBody<BuildsListResponse> _response;
 
@@ -16,9 +16,12 @@ namespace Fuyu.Backend.EFT.Controllers.Http
             _response = Json.Parse<ResponseBody<BuildsListResponse>>(json);
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
-            return context.SendJsonAsync(Json.Stringify(_response));
+            // TODO: generate this
+            // --seionmoya, 2024-11-18
+            var text = Json.Stringify(_response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/CheckVersionController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/CheckVersionController.cs
@@ -1,18 +1,20 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class CheckVersionController : HttpController
+    public class CheckVersionController : EftHttpController
     {
         public CheckVersionController() : base("/client/checkVersion")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
+            // TODO: handle this
+            // --seionmoya, 2024-11-18
             var response = new ResponseBody<CheckVersionResponse>()
             {
                 data = new CheckVersionResponse()
@@ -22,7 +24,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 }
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/ClientInsuranceItemsListCostController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/ClientInsuranceItemsListCostController.cs
@@ -4,19 +4,19 @@ using System.Linq;
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
 using Fuyu.Backend.BSG.Models.Requests;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Hashing;
-using Fuyu.Common.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class ClientInsuranceItemsListCostController : HttpController<InsuranceCostRequest>
+    public class ClientInsuranceItemsListCostController : EftHttpController<InsuranceCostRequest>
     {
         public ClientInsuranceItemsListCostController() : base("/client/insurance/items/list/cost")
         {
         }
 
-        public override Task RunAsync(HttpContext context, InsuranceCostRequest body)
+        public override Task RunAsync(EftHttpContext context, InsuranceCostRequest body)
         {
             var profile = EftOrm.GetActiveProfile(context.GetSessionId());
             var items = profile.Pmc.Inventory.Items.FindAll(i => body.ItemIds.Contains(i.Id));
@@ -44,7 +44,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 response.errmsg = "One or more items could not be found on the backend";
             }
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/ClientItemsPriceController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/ClientItemsPriceController.cs
@@ -5,14 +5,14 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
 using Fuyu.Backend.BSG.Models.Trading;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Collections;
 using Fuyu.Common.Hashing;
-using Fuyu.Common.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public partial class ClientItemsPriceController : HttpController
+    public partial class ClientItemsPriceController : EftHttpController
     {
         [GeneratedRegex(@"^/client/items/prices(/(?<traderId>[A-Za-z0-9]+))?$")]
         private static partial Regex PathExpression();
@@ -21,7 +21,7 @@ namespace Fuyu.Backend.EFT.Controllers.Http
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
             var parameters = context.GetPathParameters(this);
             var profile = EftOrm.GetActiveProfile(context.GetSessionId());
@@ -55,7 +55,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 response.data = new Dictionary<MongoId, float>();
             }
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/CustomizationController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/CustomizationController.cs
@@ -2,18 +2,18 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using Fuyu.Backend.BSG.Models.Customization;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class CustomizationController : HttpController
+    public class CustomizationController : EftHttpController
     {
         public CustomizationController() : base("/client/customization")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
             var customizations = EftOrm.GetCustomizations();
             var response = new ResponseBody<Dictionary<string, CustomizationTemplate>>()
@@ -21,7 +21,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 data = customizations
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/CustomizationStorageController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/CustomizationStorageController.cs
@@ -1,17 +1,17 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class CustomizationStorageController : HttpController
+    public class CustomizationStorageController : EftHttpController
     {
         public CustomizationStorageController() : base("/client/trading/customization/storage")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
             var sessionId = context.GetSessionId();
             var profile = EftOrm.GetActiveProfile(sessionId);
@@ -25,7 +25,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 }
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/FilesController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/FilesController.cs
@@ -2,12 +2,12 @@
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.IO;
-using Fuyu.Common.Networking;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public partial class FilesController : HttpController
+    public partial class FilesController : EftHttpController
     {
         [GeneratedRegex(@"^/files/(?<path>.+)$")]
         private static partial Regex PathExpression();
@@ -16,7 +16,7 @@ namespace Fuyu.Backend.EFT.Controllers.Http
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
             var parameters = context.GetPathParameters(this);
             var path = parameters["path"];
@@ -28,7 +28,10 @@ namespace Fuyu.Backend.EFT.Controllers.Http
             {
                 var buffer = Resx.GetBytes("eft", resourceLocation);
 
-                return context.SendBinaryAsync(buffer, $"image/{extension}", false);
+                // NOTE: file handling is done in UnityWebRequestTexture.GetTexture
+                //       instead of EFT's own HTTP client
+                // -- seionmoya, 2024-11-18
+                return context.SendBinaryAsync(buffer, $"image/{extension}", false, false);
             }
             catch (Exception ex)
             {

--- a/Fuyu.Backend.EFT/Controllers/Http/FriendListController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/FriendListController.cs
@@ -1,18 +1,20 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class FriendListController : HttpController
+    public class FriendListController : EftHttpController
     {
         public FriendListController() : base("/client/friend/list")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
+            // TODO: generate this
+            // --seionmoya, 2024-11-18
             var response = new ResponseBody<FriendListResponse>()
             {
                 data = new FriendListResponse()
@@ -23,7 +25,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 }
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/FriendRequestListInboxController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/FriendRequestListInboxController.cs
@@ -1,24 +1,27 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class FriendRequestListInboxController : HttpController
+    public class FriendRequestListInboxController : EftHttpController
     {
         public FriendRequestListInboxController() : base("/client/friend/request/list/inbox")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
+            // TODO: generate this
+            // --seionmoya, 2024-11-18
             var response = new ResponseBody<object[]>()
             {
                 data = []
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/FriendRequestListOutboxController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/FriendRequestListOutboxController.cs
@@ -1,24 +1,27 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class FriendRequestListOutboxController : HttpController
+    public class FriendRequestListOutboxController : EftHttpController
     {
         public FriendRequestListOutboxController() : base("/client/friend/request/list/outbox")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
+            // TODO: generate this
+            // --seionmoya, 2024-11-18
             var response = new ResponseBody<object[]>()
             {
                 data = []
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/FuyuGameLoginController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/FuyuGameLoginController.cs
@@ -1,19 +1,19 @@
 using System.Threading.Tasks;
-using Fuyu.Backend.EFT.Services;
 using Fuyu.Backend.Common.Models.Requests;
 using Fuyu.Backend.Common.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
+using Fuyu.Backend.EFT.Services;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class FuyuGameLoginController : HttpController<FuyuGameLoginRequest>
+    public class FuyuGameLoginController : EftHttpController<FuyuGameLoginRequest>
     {
         public FuyuGameLoginController() : base("/fuyu/game/login")
         {
         }
 
-        public override Task RunAsync(HttpContext context, FuyuGameLoginRequest request)
+        public override Task RunAsync(EftHttpContext context, FuyuGameLoginRequest request)
         {
             var sessionId = AccountService.LoginAccount(request.AccountId);
             var response = new FuyuGameLoginResponse()
@@ -21,7 +21,10 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 SessionId = sessionId
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            // NOTE: no need for encryption, request runs internal
+            // -- seionmoya, 2024-11-18
+            return context.SendJsonAsync(text, false, false);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/FuyuGameRegisterController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/FuyuGameRegisterController.cs
@@ -1,19 +1,19 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.Common.Models.Requests;
 using Fuyu.Backend.Common.Models.Responses;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Backend.EFT.Services;
-using Fuyu.Common.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class FuyuGameRegisterController : HttpController<FuyuGameRegisterRequest>
+    public class FuyuGameRegisterController : EftHttpController<FuyuGameRegisterRequest>
     {
         public FuyuGameRegisterController() : base("/fuyu/game/register")
         {
         }
 
-        public override Task RunAsync(HttpContext context, FuyuGameRegisterRequest request)
+        public override Task RunAsync(EftHttpContext context, FuyuGameRegisterRequest request)
         {
             var accountId = AccountService.RegisterAccount(request.Username, request.Edition);
             var response = new FuyuGameRegisterResponse()
@@ -21,7 +21,10 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 AccountId = accountId
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            // NOTE: no need for encryption, request runs internal
+            // -- seionmoya, 2024-11-18
+            return context.SendJsonAsync(text, false, false);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/GameBotGenerateController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/GameBotGenerateController.cs
@@ -2,19 +2,19 @@ using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Profiles;
 using Fuyu.Backend.BSG.Models.Responses;
 using Fuyu.Backend.BSG.Models.Requests;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Backend.EFT.Services;
-using Fuyu.Common.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class GameBotGenerateController : HttpController<GameBotGenerateRequest>
+    public class GameBotGenerateController : EftHttpController<GameBotGenerateRequest>
     {
         public GameBotGenerateController() : base("/client/game/bot/generate")
         {
         }
 
-        public override Task RunAsync(HttpContext context, GameBotGenerateRequest request)
+        public override Task RunAsync(EftHttpContext context, GameBotGenerateRequest request)
         {
             var profiles = BotService.GetBots(request.conditions);
             var response = new ResponseBody<Profile[]>()
@@ -22,7 +22,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 data = profiles
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/GameConfigController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/GameConfigController.cs
@@ -1,23 +1,25 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
 using Fuyu.Backend.BSG.Models.Servers;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class GameConfigController : HttpController
+    public class GameConfigController : EftHttpController
     {
         public GameConfigController() : base("/client/game/config")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
             var response = new ResponseBody<GameConfigResponse>
             {
                 data = new GameConfigResponse()
                 {
+                    // TODO: don't use hardcoded path
+                    // --seionmoya, 2024-11-18
                     backend = new Backends()
                     {
                         Lobby = "http://localhost:8010",
@@ -26,18 +28,25 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                         Main = "http://localhost:8010",
                         RagFair = "http://localhost:8010"
                     },
+                    // TODO: generate this
+                    // --seionmoya, 2024-11-18
                     utc_time = 1724450891.010541,
                     reportAvailable = true,
+                    // TODO: handle this
+                    // --seionmoya, 2024-11-18
                     purchasedGames = new PurchasedGames()
                     {
                         eft = true,
                         arena = true
                     },
+                    // TODO: handle this
+                    // --seionmoya, 2024-11-18
                     isGameSynced = true
                 }
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/GameKeepaliveController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/GameKeepaliveController.cs
@@ -1,18 +1,20 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class GameKeepaliveController : HttpController
+    public class GameKeepaliveController : EftHttpController
     {
         public GameKeepaliveController() : base("/client/game/keepalive")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
+            // TODO: generate this
+            // --seionmoya, 2024-11-18
             var response = new ResponseBody<GameKeepaliveResponse>
             {
                 data = new GameKeepaliveResponse()
@@ -22,7 +24,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 }
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/GameLogoutController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/GameLogoutController.cs
@@ -1,18 +1,20 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class GameLogoutController : HttpController
+    public class GameLogoutController : EftHttpController
     {
         public GameLogoutController() : base("/client/game/logout")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
+            // TODO: handle this
+            // --seionmoya, 2024-11-18
             var response = new ResponseBody<GameLogoutResponse>()
             {
                 data = new GameLogoutResponse()
@@ -21,7 +23,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 }
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/GameModeController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/GameModeController.cs
@@ -2,23 +2,24 @@ using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
 using Fuyu.Backend.BSG.Models.Requests;
 using Fuyu.Backend.BSG.Models.Accounts;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class GameModeController : HttpController<ClientGameModeRequest>
+    public class GameModeController : EftHttpController<ClientGameModeRequest>
     {
         public GameModeController() : base("/client/game/mode")
         {
         }
 
-        public override Task RunAsync(HttpContext context, ClientGameModeRequest body)
+        public override Task RunAsync(EftHttpContext context, ClientGameModeRequest body)
         {
             var account = EftOrm.GetAccount(context.GetSessionId());
 
             if (body.SessionMode == null)
             {
+                // wiped profile
                 body.SessionMode = ESessionMode.Pve;
             }
 
@@ -26,6 +27,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
 
             var response = new ResponseBody<GameModeResponse>()
             {
+                // TODO: don't use hardcoded address
+                // --seionmoya, 2024-11-18
                 data = new GameModeResponse()
                 {
                     GameMode = body.SessionMode,
@@ -33,7 +36,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 }
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/GameProfileCreateController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/GameProfileCreateController.cs
@@ -1,8 +1,8 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
 using Fuyu.Backend.BSG.Models.Requests;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Backend.EFT.Services;
-using Fuyu.Common.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
@@ -10,17 +10,18 @@ namespace Fuyu.Backend.EFT.Controllers.Http
     // TODO:
     // * move code into TemplateTable and ProfileService
     // -- seionmoya, 2024/09/02
-    public class GameProfileCreateController : HttpController<GameProfileCreateRequest>
+    public class GameProfileCreateController : EftHttpController<GameProfileCreateRequest>
     {
         public GameProfileCreateController() : base("/client/game/profile/create")
         {
         }
 
-        public override Task RunAsync(HttpContext context, GameProfileCreateRequest request)
+        public override Task RunAsync(EftHttpContext context, GameProfileCreateRequest request)
         {
             var sessionId = context.GetSessionId();
             var account = EftOrm.GetAccount(sessionId);
             var pmcId = ProfileService.WipeProfile(account, request.side, request.headId, request.voiceId);
+
             var response = new ResponseBody<GameProfileCreateResponse>()
             {
                 data = new GameProfileCreateResponse()
@@ -29,7 +30,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 }
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/GameProfileItemsMovingController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/GameProfileItemsMovingController.cs
@@ -4,12 +4,12 @@ using Fuyu.Backend.BSG.Models.ItemEvents;
 using Fuyu.Backend.BSG.Models.Responses;
 using Fuyu.Backend.BSG.Networking;
 using Fuyu.Backend.EFT.Controllers.ItemEvents;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class GameProfileItemsMovingController : HttpController<JObject>
+    public class GameProfileItemsMovingController : EftHttpController<JObject>
     {
         public ItemEventRouter ItemEventRouter { get; } = new ItemEventRouter();
 
@@ -41,7 +41,7 @@ namespace Fuyu.Backend.EFT.Controllers.Http
             ItemEventRouter.AddController<ToggleItemEventController>();
         }
 
-        public override async Task RunAsync(HttpContext context, JObject request)
+        public override async Task RunAsync(EftHttpContext context, JObject request)
         {
             if (!request.ContainsKey("data"))
             {
@@ -82,7 +82,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 data = itemEventResponse
             };
 
-            await context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            await context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/GameProfileListController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/GameProfileListController.cs
@@ -1,18 +1,18 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Profiles;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class GameProfileListController : HttpController
+    public class GameProfileListController : EftHttpController
     {
         public GameProfileListController() : base("/client/game/profile/list")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
             var sessionId = context.GetSessionId();
             var profile = EftOrm.GetActiveProfile(sessionId);
@@ -32,7 +32,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 data = profiles
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/GameProfileNicknameReservedController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/GameProfileNicknameReservedController.cs
@@ -1,17 +1,17 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class GameProfileNicknameReservedController : HttpController
+    public class GameProfileNicknameReservedController : EftHttpController
     {
         public GameProfileNicknameReservedController() : base("/client/game/profile/nickname/reserved")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
             var sessionId = context.GetSessionId();
             var account = EftOrm.GetAccount(sessionId);
@@ -21,7 +21,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 data = account.Username
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/GameProfileNicknameValidateController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/GameProfileNicknameValidateController.cs
@@ -1,18 +1,18 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Requests;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class GameProfileNicknameValidateController : HttpController<GameProfileNicknameValidateRequest>
+    public class GameProfileNicknameValidateController : EftHttpController<GameProfileNicknameValidateRequest>
     {
         public GameProfileNicknameValidateController() : base("/client/game/profile/nickname/validate")
         {
         }
 
-        public override Task RunAsync(HttpContext context, GameProfileNicknameValidateRequest request)
+        public override Task RunAsync(EftHttpContext context, GameProfileNicknameValidateRequest request)
         {
             // TODO:
             // * validate nickname usage
@@ -26,7 +26,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 }
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/GameProfileSelectController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/GameProfileSelectController.cs
@@ -1,18 +1,20 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class GameProfileSelectController : HttpController
+    public class GameProfileSelectController : EftHttpController
     {
         public GameProfileSelectController() : base("/client/game/profile/select")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
+            // TODO: handle this
+            // --seionmoya, 2024-11-18
             var response = new ResponseBody<ProfileSelectResponse>()
             {
                 data = new ProfileSelectResponse()
@@ -21,7 +23,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 }
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/GameStartController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/GameStartController.cs
@@ -1,18 +1,20 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class GameStartController : HttpController
+    public class GameStartController : EftHttpController
     {
         public GameStartController() : base("/client/game/start")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
+            // TODO: generate this
+            // --seionmoya, 2024-11-18
             var response = new ResponseBody<GameStartResponse>()
             {
                 data = new GameStartResponse()
@@ -21,7 +23,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 }
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/GameVersionValidateController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/GameVersionValidateController.cs
@@ -1,24 +1,27 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class GameVersionValidateController : HttpController
+    public class GameVersionValidateController : EftHttpController
     {
         public GameVersionValidateController() : base("/client/game/version/validate")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
+            // TODO: handle this
+            // --seionmoya, 2024-11-18
             var response = new ResponseBody<object>()
             {
                 data = null
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/GetMetricsConfigController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/GetMetricsConfigController.cs
@@ -1,17 +1,17 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class GetMetricsConfigController : HttpController
+    public class GetMetricsConfigController : EftHttpController
     {
         public GetMetricsConfigController() : base("/client/getMetricsConfig")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
             var response = new ResponseBody<GetMetricsConfigResponse>()
             {
@@ -26,7 +26,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 }
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/GetTraderAssortController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/GetTraderAssortController.cs
@@ -2,12 +2,12 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
 using Fuyu.Backend.BSG.Models.Trading;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public partial class GetTraderAssortController : HttpController
+    public partial class GetTraderAssortController : EftHttpController
     {
         [GeneratedRegex("/client/trading/api/getTraderAssort/(?<traderId>[A-Za-z0-9]+)")]
         private static partial Regex PathExpression();
@@ -16,10 +16,13 @@ namespace Fuyu.Backend.EFT.Controllers.Http
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
             var parameters = context.GetPathParameters(this);
             var traderId = parameters["traderId"];
+
+            // TODO: handle this
+            // --seionmoya, 2024-11-18
             var response = new ResponseBody<TraderAssort>
             {
                 data = new TraderAssort
@@ -32,7 +35,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 }
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/GlobalsController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/GlobalsController.cs
@@ -1,17 +1,20 @@
 using System.Threading.Tasks;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class GlobalsController : HttpController
+    public class GlobalsController : EftHttpController
     {
         public GlobalsController() : base("/client/globals")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
-            return context.SendJsonAsync(EftOrm.GetGlobals());
+            // TODO: generate this
+            // --seionmoya, 2024-11-18
+            var text = EftOrm.GetGlobals();
+            return context.SendJsonAsync(text);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/HandbookTemplatesController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/HandbookTemplatesController.cs
@@ -1,17 +1,20 @@
 using System.Threading.Tasks;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class HandbookTemplatesController : HttpController
+    public class HandbookTemplatesController : EftHttpController
     {
         public HandbookTemplatesController() : base("/client/handbook/templates")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
-            return context.SendJsonAsync(EftOrm.GetHandbook());
+            // TODO: generate this
+            // --seionmoya, 2024-11-18
+            var text = EftOrm.GetHandbook();
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/HideoutAreasController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/HideoutAreasController.cs
@@ -1,17 +1,20 @@
 using System.Threading.Tasks;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class HideoutAreasController : HttpController
+    public class HideoutAreasController : EftHttpController
     {
         public HideoutAreasController() : base("/client/hideout/areas")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
-            return context.SendJsonAsync(EftOrm.GetHideoutAreas());
+            // TODO: generate this
+            // --seionmoya, 2024-11-18
+            var text = EftOrm.GetHideoutAreas();
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/HideoutProductionRecipesController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/HideoutProductionRecipesController.cs
@@ -1,17 +1,20 @@
 using System.Threading.Tasks;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class HideoutProductionRecipesController : HttpController
+    public class HideoutProductionRecipesController : EftHttpController
     {
         public HideoutProductionRecipesController() : base("/client/hideout/production/recipes")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
-            return context.SendJsonAsync(EftOrm.GetHideoutProductionRecipes());
+            // TODO: generate this
+            // --seionmoya, 2024-11-18
+            var text = EftOrm.GetHideoutProductionRecipes();
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/HideoutQteListController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/HideoutQteListController.cs
@@ -1,17 +1,20 @@
 using System.Threading.Tasks;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class HideoutQteListController : HttpController
+    public class HideoutQteListController : EftHttpController
     {
         public HideoutQteListController() : base("/client/hideout/qte/list")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
-            return context.SendJsonAsync(EftOrm.GetHideoutQteList());
+            // TODO: generate this
+            // --seionmoya, 2024-11-18
+            var text = EftOrm.GetHideoutQteList();
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/HideoutSettingsController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/HideoutSettingsController.cs
@@ -1,21 +1,23 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class HideoutSettingsController : HttpController
+    public class HideoutSettingsController : EftHttpController
     {
         public HideoutSettingsController() : base("/client/hideout/settings")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
             var json = EftOrm.GetHideoutSettings();
             var response = Json.Parse<ResponseBody<HideoutSettingsResponse>>(json);
-            return context.SendJsonAsync(Json.Stringify(response));
+
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/ItemsController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/ItemsController.cs
@@ -1,17 +1,20 @@
 using System.Threading.Tasks;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class ItemsController : HttpController
+    public class ItemsController : EftHttpController
     {
         public ItemsController() : base("/client/items")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
-            return context.SendJsonAsync(EftOrm.GetItems());
+            // TODO: generate this
+            // --seionmoya, 2024-11-18
+            var text = EftOrm.GetItems();
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/LanguagesController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/LanguagesController.cs
@@ -1,18 +1,18 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class LanguagesController : HttpController
+    public class LanguagesController : EftHttpController
     {
         public LanguagesController() : base("/client/languages")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
             var languages = EftOrm.GetLanguages();
             var response = new ResponseBody<Dictionary<string, string>>
@@ -20,7 +20,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 data = languages
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/LocalGameWeatherController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/LocalGameWeatherController.cs
@@ -1,17 +1,20 @@
 using System.Threading.Tasks;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class LocalGameWeatherController : HttpController
+    public class LocalGameWeatherController : EftHttpController
     {
         public LocalGameWeatherController() : base("/client/localGame/weather")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
-            return context.SendJsonAsync(EftOrm.GetLocalWeather());
+            // TODO: generate this
+            // --seionmoya, 2024-11-18
+            var text = EftOrm.GetLocalWeather();
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/LocaleController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/LocaleController.cs
@@ -2,12 +2,12 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Backend.BSG.Services;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
+using Fuyu.Backend.EFT.Services;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public partial class LocaleController : HttpController
+    public partial class LocaleController : EftHttpController
     {
         [GeneratedRegex("^/client/locale/(?<languageId>[a-z]+(-[a-z]+)?)$")]
         private static partial Regex PathExpression();
@@ -16,7 +16,7 @@ namespace Fuyu.Backend.EFT.Controllers.Http
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
             var parameters = context.GetPathParameters(this);
 

--- a/Fuyu.Backend.EFT/Controllers/Http/LocationsController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/LocationsController.cs
@@ -1,23 +1,24 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Locations;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class LocationsController : HttpController
+    public class LocationsController : EftHttpController
     {
         public LocationsController() : base("/client/locations")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
             var json = EftOrm.GetLocations();
             var locations = Json.Parse<ResponseBody<WorldMap>>(json);
             var response = Json.Stringify(locations);
-            return context.SendJsonAsync(response);
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/MailDialogListController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/MailDialogListController.cs
@@ -1,24 +1,27 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class MailDialogListController : HttpController
+    public class MailDialogListController : EftHttpController
     {
         public MailDialogListController() : base("/client/mail/dialog/list")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
+            // TODO: handle this
+            // --seionmoya, 2024-11-18
             var response = new ResponseBody<object[]>
             {
                 data = []
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/MatchGroupCurrentController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/MatchGroupCurrentController.cs
@@ -1,18 +1,20 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class MatchGroupCurrentController : HttpController
+    public class MatchGroupCurrentController : EftHttpController
     {
         public MatchGroupCurrentController() : base("/client/match/group/current")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
+            // TODO: handle this
+            // --seionmoya, 2024-11-18
             var response = new ResponseBody<MatchGroupCurrentResponse>()
             {
                 data = new MatchGroupCurrentResponse()
@@ -22,7 +24,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 }
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/MatchGroupExitFromMenuController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/MatchGroupExitFromMenuController.cs
@@ -1,24 +1,27 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class MatchGroupExitFromMenuController : HttpController
+    public class MatchGroupExitFromMenuController : EftHttpController
     {
         public MatchGroupExitFromMenuController() : base("/client/match/group/exit_from_menu")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
+            // TODO: handle this
+            // --seionmoya, 2024-11-18
             var response = new ResponseBody<object>()
             {
                 data = null
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/MatchGroupInviteCancelAllController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/MatchGroupInviteCancelAllController.cs
@@ -1,24 +1,27 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class MatchGroupInviteCancelAllController : HttpController
+    public class MatchGroupInviteCancelAllController : EftHttpController
     {
         public MatchGroupInviteCancelAllController() : base("/client/match/group/invite/cancel-all")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
+            // TODO: handle this
+            // --seionmoya, 2024-11-18
             var response = new ResponseBody<bool>()
             {
                 data = true
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/MatchLocalEndController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/MatchLocalEndController.cs
@@ -2,26 +2,29 @@ using System.Linq;
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
 using Fuyu.Backend.BSG.Models.Requests;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class MatchLocalEndController : HttpController<MatchLocalEndRequest>
+    public class MatchLocalEndController : EftHttpController<MatchLocalEndRequest>
     {
         public MatchLocalEndController() : base("/client/match/local/end")
         {
         }
 
-        public override Task RunAsync(HttpContext context, MatchLocalEndRequest body)
+        public override Task RunAsync(EftHttpContext context, MatchLocalEndRequest body)
         {
             var sessionId = context.GetSessionId();
 
             var profile = EftOrm.GetActiveProfile(sessionId);
 
+            // TODO: move this to a service
+            // --seionmoya, 2024-11-18
+
             // NOTE: This data is not present in what the client sends as one of BSG's anticheat measures
             // which prevents your inraid inventory info from knowing what is in someone's stash
-            // so I have to manually add the existing data that should be there which I think is ;ess effort
+            // so I have to manually add the existing data that should be there which I think is less effort
             // than manually taking the data that we want from the client's request
             // -- nexus4880, 2024-10-14
             body.results.profile.Info.LowerNickname = profile.Pmc.Info.LowerNickname;
@@ -47,7 +50,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 data = null
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/MatchLocalStartController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/MatchLocalStartController.cs
@@ -1,12 +1,12 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Requests;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.IO;
-using Fuyu.Common.Networking;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class MatchLocalStartController : HttpController<MatchLocalStartRequest>
+    public class MatchLocalStartController : EftHttpController<MatchLocalStartRequest>
     {
         private readonly Dictionary<string, string> _locations;
 
@@ -28,11 +28,14 @@ namespace Fuyu.Backend.EFT.Controllers.Http
             };
         }
 
-        public override Task RunAsync(HttpContext context, MatchLocalStartRequest request)
+        public override Task RunAsync(EftHttpContext context, MatchLocalStartRequest request)
         {
+            // TODO: generate this
+            // --seionmoya, 2024-11-18
             var location = request.location;
 
-            return context.SendJsonAsync(_locations[location]);
+            var text = _locations[location];
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/MenuLocaleController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/MenuLocaleController.cs
@@ -1,12 +1,12 @@
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public partial class MenuLocaleController : HttpController
+    public partial class MenuLocaleController : EftHttpController
     {
         [GeneratedRegex("^/client/menu/locale/(?<languageId>[a-z]+(-[a-z]+)?)$")]
         private static partial Regex PathExpression();
@@ -15,7 +15,7 @@ namespace Fuyu.Backend.EFT.Controllers.Http
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
             var parameters = context.GetPathParameters(this);
 
@@ -26,7 +26,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 data = locale
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/NotifierChannelCreateController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/NotifierChannelCreateController.cs
@@ -1,20 +1,23 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Hashing;
-using Fuyu.Common.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class NotifierChannelCreateController : HttpController
+    public class NotifierChannelCreateController : EftHttpController
     {
         public NotifierChannelCreateController() : base("/client/notifier/channel/create")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
             var channelId = SimpleId.Generate(64);
+            
+            // TODO: don't hardcode address
+            // --seionmoya, 2024-11-18
             var response = new ResponseBody<NotifierChannelCreateResponse>
             {
                 data = new NotifierChannelCreateResponse()
@@ -26,7 +29,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 }
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/ProfileSettingsController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/ProfileSettingsController.cs
@@ -1,24 +1,27 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class ProfileSettingsController : HttpController
+    public class ProfileSettingsController : EftHttpController
     {
         public ProfileSettingsController() : base("/client/profile/settings")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
+            // TODO: handle this
+            // --seionmoya, 2024-11-18
             var response = new ResponseBody<bool>()
             {
                 data = true
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/ProfileStatusController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/ProfileStatusController.cs
@@ -1,23 +1,25 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Multiplayer;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class ProfileStatusController : HttpController
+    public class ProfileStatusController : EftHttpController
     {
         public ProfileStatusController() : base("/client/profile/status")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
             var sessionId = context.GetSessionId();
 
             var profile = EftOrm.GetActiveProfile(sessionId);
 
+            // TODO: generate this
+            // --seionmoya, 2024-11-18
             var response = new ResponseBody<ProfileStatusResponse>()
             {
                 data = new ProfileStatusResponse()
@@ -47,7 +49,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 }
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/PutMetricsController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/PutMetricsController.cs
@@ -1,24 +1,27 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class PutMetricsController : HttpController
+    public class PutMetricsController : EftHttpController
     {
         public PutMetricsController() : base("/client/putMetrics")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
+            // TODO: handle this
+            // --seionmoya, 2024-11-18
             var response = new ResponseBody<object>()
             {
                 data = null
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/QuestListController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/QuestListController.cs
@@ -1,17 +1,20 @@
 using System.Threading.Tasks;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class QuestListController : HttpController
+    public class QuestListController : EftHttpController
     {
         public QuestListController() : base("/client/quest/list")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
-            return context.SendJsonAsync(EftOrm.GetQuest());
+            // TODO: generate this
+            // --seionmoya, 2024-11-18
+            var text = EftOrm.GetQuest();
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/RaidConfigurationController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/RaidConfigurationController.cs
@@ -1,24 +1,27 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class RaidConfigurationController : HttpController
+    public class RaidConfigurationController : EftHttpController
     {
         public RaidConfigurationController() : base("/client/raid/configuration")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
+            // TODO: handle this
+            // --seionmoya, 2024-11-18
             var response = new ResponseBody<object>()
             {
                 data = null
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/RepeatableQuestActivityPeriodsController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/RepeatableQuestActivityPeriodsController.cs
@@ -1,24 +1,27 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class RepeatableQuestActivityPeriodsController : HttpController
+    public class RepeatableQuestActivityPeriodsController : EftHttpController
     {
         public RepeatableQuestActivityPeriodsController() : base("/client/repeatalbeQuests/activityPeriods")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
+            // TODO: generate this
+            // --seionmoya, 2024-11-18
             var response = new ResponseBody<object[]>
             {
                 data = []
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/ServerListController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/ServerListController.cs
@@ -1,18 +1,18 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
 using Fuyu.Backend.BSG.Models.Servers;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class ServerListController : HttpController
+    public class ServerListController : EftHttpController
     {
         public ServerListController() : base("/client/server/list")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
             var response = new ResponseBody<ServerInfo[]>()
             {
@@ -25,7 +25,8 @@ namespace Fuyu.Backend.EFT.Controllers.Http
                 ]
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/SettingsController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/SettingsController.cs
@@ -1,17 +1,20 @@
 using System.Threading.Tasks;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class SettingsController : HttpController
+    public class SettingsController : EftHttpController
     {
         public SettingsController() : base("/client/settings")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
-            return context.SendJsonAsync(EftOrm.GetSettings());
+            // TODO: generate this
+            // --seionmoya, 2024-11-18
+            var text = EftOrm.GetSettings();
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/SurveyController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/SurveyController.cs
@@ -1,24 +1,27 @@
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class SurveyController : HttpController
+    public class SurveyController : EftHttpController
     {
         public SurveyController() : base("/client/survey")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
+            // TODO: generate this
+            // --seionmoya, 2024-11-18
             var response = new ResponseBody<object>()
             {
                 data = null
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/TraderSettingsController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/TraderSettingsController.cs
@@ -2,25 +2,26 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
 using Fuyu.Backend.BSG.Models.Trading;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class TraderSettingsController : HttpController
+    public class TraderSettingsController : EftHttpController
     {
         public TraderSettingsController() : base("/client/trading/api/traderSettings")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
             var response = new ResponseBody<IEnumerable<TraderTemplate>>
             {
                 data = TraderDatabase.GetTraderTemplates().Values
             };
 
-            return context.SendJsonAsync(Json.Stringify(response));
+            var text = Json.Stringify(response);
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Controllers/Http/WeatherController.cs
+++ b/Fuyu.Backend.EFT/Controllers/Http/WeatherController.cs
@@ -1,17 +1,20 @@
 using System.Threading.Tasks;
-using Fuyu.Common.Networking;
+using Fuyu.Backend.EFT.Networking;
 
 namespace Fuyu.Backend.EFT.Controllers.Http
 {
-    public class WeatherController : HttpController
+    public class WeatherController : EftHttpController
     {
         public WeatherController() : base("/client/weather")
         {
         }
 
-        public override Task RunAsync(HttpContext context)
+        public override Task RunAsync(EftHttpContext context)
         {
-            return context.SendJsonAsync(EftOrm.GetWeather());
+            // TODO: generate this
+            // --seionmoya, 2024-11-18
+            var text = EftOrm.GetWeather();
+            return context.SendJsonAsync(text, true, true);
         }
     }
 }

--- a/Fuyu.Backend.EFT/Networking/EftHttpContext.cs
+++ b/Fuyu.Backend.EFT/Networking/EftHttpContext.cs
@@ -23,7 +23,7 @@ namespace Fuyu.Backend.EFT.Networking
                 var body = ms.ToArray();
                 var encryption = GetEncryption();
 
-                if (encryption != string.Empty)
+                if (!string.IsNullOrWhiteSpace(encryption))
                 {
                     switch (encryption)
                     {

--- a/Fuyu.Backend.EFT/Networking/EftHttpContext.cs
+++ b/Fuyu.Backend.EFT/Networking/EftHttpContext.cs
@@ -1,0 +1,111 @@
+using System.IO;
+using System.IO.Compression;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Fuyu.Common.Compression;
+using Fuyu.Common.Networking;
+
+namespace Fuyu.Backend.EFT.Networking
+{
+    public class EftHttpContext : HttpContext
+    {
+        public EftHttpContext(HttpListenerRequest request, HttpListenerResponse response) : base(request, response)
+        {
+        }
+
+        public override byte[] GetBinary()
+        {
+            using (var ms = new MemoryStream())
+            {
+                Request.InputStream.CopyTo(ms);
+
+                var body = ms.ToArray();
+                var encryption = GetEncryption();
+
+                if (encryption != string.Empty)
+                {
+                    switch (encryption)
+                    {
+                        case "aes":
+                            // TODO: handle AES-192 encryption
+                            // body = CryptographyService.DecryptAes(body);
+                            break;
+
+                        default:
+                            throw new InvalidDataException(encryption);
+                    }
+                }
+
+                if (MemoryZlib.IsCompressed(body))
+                {
+                    body = MemoryZlib.Decompress(body);
+                }
+
+                return body;
+            }
+        }
+
+        protected Task SendAsync(byte[] data, string mime, HttpStatusCode status, bool zipped, bool encrypted)
+        {
+            bool hasData = !(data == null);
+
+            // Used for postman debugging by Nexus4880
+            // -- seionmoya, 2024-11-18
+#if DEBUG
+            if (Request.Headers["X-Require-Plaintext"] != null)
+            {
+                zipped = false;
+                encrypted = false;
+            }
+#endif
+
+            if (hasData && zipped)
+            {
+                data = MemoryZlib.Compress(data, CompressionLevel.SmallestSize);
+            }
+
+            if (hasData && encrypted)
+            {
+                // TODO: handle X-Encryption: aes
+                /*
+                Response.Headers.Add("X-Encryption", "aes");
+                data = CryptographyService.EncryptAes(data);
+                */
+                encrypted = false;
+            }
+
+            return SendAsync(data, mime, status);
+        }
+
+        public Task SendBinaryAsync(byte[] data, string mime, bool zipped, bool encrypted)
+        {
+            return SendAsync(data, mime, HttpStatusCode.OK, zipped, encrypted);
+        }
+
+        public Task SendJsonAsync(string text, bool zipped, bool encrypted)
+        {
+            var encoded = Encoding.UTF8.GetBytes(text);
+            var mime = zipped || encrypted
+                ? "application/octet-stream"
+                : "application/json; charset=utf-8";
+
+            return SendAsync(encoded, mime, HttpStatusCode.OK, zipped, encrypted);
+        }
+
+        public string GetEncryption()
+        {
+            return Request.Headers["X-Encryption"];
+        }
+
+        public string GetETag()
+        {
+            return Request.Headers["If-None-Match"];
+        }
+
+        public string GetSessionId()
+        {
+            return Request.Cookies["PHPSESSID"].Value;
+        }
+    }
+}

--- a/Fuyu.Backend.EFT/Networking/EftHttpController.cs
+++ b/Fuyu.Backend.EFT/Networking/EftHttpController.cs
@@ -19,10 +19,7 @@ namespace Fuyu.Backend.EFT.Networking
 
         public override Task RunAsync(HttpContext context)
         {
-            // NOTE: assumes HttpController can be safely downcasted into EftHttpControler
-            // -- seionmoya, 2024-11-18
-            var downcast = (EftHttpContext)context;
-
+            var downcast = new EftHttpContext(context.Request, context.Response);
             return RunAsync(downcast);
         }
 

--- a/Fuyu.Backend.EFT/Networking/EftHttpController.cs
+++ b/Fuyu.Backend.EFT/Networking/EftHttpController.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Fuyu.Common.Networking;
+
+namespace Fuyu.Backend.EFT.Networking
+{
+    public abstract class EftHttpController : HttpController
+    {
+        protected EftHttpController(Regex pattern) : base(pattern)
+        {
+            // match dynamic paths
+        }
+
+        protected EftHttpController(string path) : base(path)
+        {
+            // match static paths
+        }
+
+        public override Task RunAsync(HttpContext context)
+        {
+            // NOTE: assumes HttpController can be safely downcasted into EftHttpControler
+            // -- seionmoya, 2024-11-18
+            var downcast = (EftHttpContext)context;
+
+            return RunAsync(downcast);
+        }
+
+        public abstract Task RunAsync(EftHttpContext context);
+    }
+
+    public abstract class EftHttpController<TRequest> : EftHttpController where TRequest : class
+    {
+        protected EftHttpController(Regex pattern) : base(pattern)
+        {
+            // match dynamic paths
+        }
+
+        protected EftHttpController(string path) : base(path)
+        {
+            // match static paths
+        }
+
+        public override Task RunAsync(EftHttpContext context)
+        {
+            // TODO:
+            // - Use better exception type
+            // -- seionmoya, 2024-10-13
+            if (!context.HasBody())
+            {
+                throw new Exception("Request does not contain body.");
+            }
+
+            var body = context.GetJson<TRequest>();
+
+            // TODO:
+            // - Use better exception type
+            // -- seionmoya, 2024-10-13
+            if (body == null)
+            {
+                throw new Exception("Body could not be parsed as TRequest.");
+            }
+
+            return RunAsync(context, body);
+        }
+
+        public abstract Task RunAsync(EftHttpContext context, TRequest body);
+    }
+}

--- a/Fuyu.Backend.EFT/Services/ETagService.cs
+++ b/Fuyu.Backend.EFT/Services/ETagService.cs
@@ -3,15 +3,15 @@ using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using Fuyu.Backend.BSG.Models.Responses;
+using Fuyu.Backend.EFT.Networking;
 using Fuyu.Common.Hashing;
-using Fuyu.Common.Networking;
 using Fuyu.Common.Serialization;
 
-namespace Fuyu.Backend.BSG.Services
+namespace Fuyu.Backend.EFT.Services
 {
     public class ETagService
     {
-        public static uint GetUIntETag(HttpContext context)
+        public static uint GetUIntETag(EftHttpContext context)
         {
             var value = context.GetETag();
 
@@ -39,7 +39,7 @@ namespace Fuyu.Backend.BSG.Services
             return cached == 0u || cached != crc;
         }
 
-        public static Task SendCachedAsync<TResponse>(HttpContext context, ResponseBody<TResponse> response)
+        public static Task SendCachedAsync<TResponse>(EftHttpContext context, ResponseBody<TResponse> response)
         {
             var cached = GetUIntETag(context);
             var crc = GetCrc(response.data);
@@ -48,7 +48,9 @@ namespace Fuyu.Backend.BSG.Services
             {
                 // outdated client cache
                 response.crc = crc;
-                return context.SendJsonAsync(Json.Stringify(response));
+
+                var text = Json.Stringify(response);
+                return context.SendJsonAsync(text, true, true);
             }
             else
             {

--- a/Fuyu.Common/Networking/HttpContext.cs
+++ b/Fuyu.Common/Networking/HttpContext.cs
@@ -35,7 +35,7 @@ namespace Fuyu.Common.Networking
 
         protected virtual Task SendAsync(byte[] data, string mime, HttpStatusCode status)
         {
-            bool hasData = !(data == null);
+            var hasData = !(data == null);
 
             Response.StatusCode = (int)status;
             Response.ContentType = mime;

--- a/Fuyu.Common/Networking/HttpContext.cs
+++ b/Fuyu.Common/Networking/HttpContext.cs
@@ -1,9 +1,7 @@
 using System.IO;
-using System.IO.Compression;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
-using Fuyu.Common.Compression;
 using Fuyu.Common.Serialization;
 
 namespace Fuyu.Common.Networking
@@ -14,74 +12,30 @@ namespace Fuyu.Common.Networking
         {
         }
 
-        public bool HasBody()
-        {
-            return Request.HasEntityBody;
-        }
-
-        public byte[] GetBinary()
+        public virtual byte[] GetBinary()
         {
             using (var ms = new MemoryStream())
             {
                 Request.InputStream.CopyTo(ms);
-
-                var body = ms.ToArray();
-
-                if (MemoryZlib.IsCompressed(body))
-                {
-                    body = MemoryZlib.Decompress(body);
-                }
-
-                return body;
+                return ms.ToArray();
             }
         }
 
-        public string GetText()
+        public virtual string GetText()
         {
             var body = GetBinary();
             return Encoding.UTF8.GetString(body);
         }
 
-        public T GetJson<T>()
+        public virtual T GetJson<T>()
         {
             var json = GetText();
             return Json.Parse<T>(json);
         }
 
-        public string GetETag()
+        protected virtual Task SendAsync(byte[] data, string mime, HttpStatusCode status)
         {
-            return Request.Headers["If-None-Match"];
-        }
-
-        public string GetSessionId()
-        {
-            return Request.Cookies["PHPSESSID"].Value;
-        }
-
-        protected Task SendAsync(byte[] data, string mime, HttpStatusCode status, bool zipped = true)
-        {
-            bool hasData = !(data is null);
-
-            // used for plaintext debugging
-            if (Request.Headers["fuyu-debug"] != null)
-            {
-                zipped = false;
-            }
-
-            if (hasData && zipped)
-            {
-                // NOTE: CompressionLevel.SmallestSize does not exist in
-                //       .NET 5 and below.
-                // -- seionmoya, 2024-10-07
-
-#if NET6_0_OR_GREATER
-                var level = CompressionLevel.SmallestSize;
-#else
-                var level = CompressionLevel.Optimal;
-#endif
-
-                data = MemoryZlib.Compress(data, level);
-            }
+            bool hasData = !(data == null);
 
             Response.StatusCode = (int)status;
             Response.ContentType = mime;
@@ -101,34 +55,20 @@ namespace Fuyu.Common.Networking
             }
         }
 
-        public Task SendStatus(HttpStatusCode status)
+        public virtual Task SendStatus(HttpStatusCode status)
         {
-            return SendAsync(null, "plain/text", status, false);
+            return SendAsync(null, "plain/text", status);
         }
 
-        public Task SendBinaryAsync(byte[] data, string mime, bool zipped = true)
+        public virtual Task SendBinaryAsync(byte[] data, string mime)
         {
-            return SendAsync(data, mime, HttpStatusCode.OK, zipped);
+            return SendAsync(data, mime, HttpStatusCode.OK);
         }
 
-        public Task SendJsonAsync(string text, bool zipped = true)
+        public virtual Task SendJsonAsync(string text)
         {
             var encoded = Encoding.UTF8.GetBytes(text);
-            var mime = zipped
-                ? "application/octet-stream"
-                : "application/json; charset=utf-8";
-
-            return SendAsync(encoded, mime, HttpStatusCode.OK, zipped);
-        }
-
-        public void Close()
-        {
-            Response.Close();
-        }
-
-        public override string ToString()
-        {
-            return $"{GetType().Name}:{Path}(HasBody:{HasBody()})";
+            return SendAsync(encoded, "application/json; charset=utf-8", HttpStatusCode.OK);
         }
     }
 }

--- a/Fuyu.Common/Networking/HttpResponse.cs
+++ b/Fuyu.Common/Networking/HttpResponse.cs
@@ -4,9 +4,6 @@ namespace Fuyu.Common.Networking
 {
     public class HttpResponse
     {
-        // TODO:
-        // * use enum instead
-        // -- seionmoya, 2024/09/19
         public HttpStatusCode Status;
 
         // TODO:

--- a/Fuyu.Common/Networking/WebRouterContext.cs
+++ b/Fuyu.Common/Networking/WebRouterContext.cs
@@ -36,5 +36,20 @@ namespace Fuyu.Common.Networking
 
             return result;
         }
+
+        public bool HasBody()
+        {
+            return Request.HasEntityBody;
+        }
+
+        public void Close()
+        {
+            Response.Close();
+        }
+
+        public override string ToString()
+        {
+            return $"{GetType().Name}:{Path}(HasBody:{HasBody()})";
+        }
     }
 }

--- a/Fuyu.Common/Networking/WebRouterContext.cs
+++ b/Fuyu.Common/Networking/WebRouterContext.cs
@@ -5,8 +5,8 @@ namespace Fuyu.Common.Networking
 {
     public class WebRouterContext : IRouterContext
     {
-        protected readonly HttpListenerRequest Request;
-        protected readonly HttpListenerResponse Response;
+        public readonly HttpListenerRequest Request;
+        public readonly HttpListenerResponse Response;
         public string Path { get; }
 
         public WebRouterContext(HttpListenerRequest request, HttpListenerResponse response)

--- a/Fuyu.Launcher.Core/Networking/CoreHttpClient.cs
+++ b/Fuyu.Launcher.Core/Networking/CoreHttpClient.cs
@@ -3,13 +3,13 @@ using System.IO.Compression;
 using System.Net.Http;
 using Fuyu.Common.Compression;
 
-namespace Fuyu.Tests.Backend.EFT.Networking
+namespace Fuyu.Launcher.Core.Networking
 {
-    public class EftHttpClient : Fuyu.Common.Networking.HttpClient
+    public class CoreHttpClient : Fuyu.Common.Networking.HttpClient
     {
         public readonly string _sessionId;
 
-        public EftHttpClient(string address, string sessionId) : base(address)
+        public CoreHttpClient(string address, string sessionId) : base(address)
         {
             _sessionId = sessionId;
         }
@@ -38,7 +38,7 @@ namespace Fuyu.Tests.Backend.EFT.Networking
             };
 
             request.Headers.Add("X-Encryption", "aes");
-            request.Headers.Add("Cookie", $"PHPSESSID={_sessionId}");
+            request.Headers.Add("Cookie", $"Session={_sessionId}");
 
             return request;
         }

--- a/Fuyu.Launcher.Core/Networking/CoreHttpClient.cs
+++ b/Fuyu.Launcher.Core/Networking/CoreHttpClient.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO.Compression;
 using System.Net.Http;
-using Fuyu.Common.Compression;
 
 namespace Fuyu.Launcher.Core.Networking
 {
@@ -12,21 +11,6 @@ namespace Fuyu.Launcher.Core.Networking
         public CoreHttpClient(string address, string sessionId) : base(address)
         {
             _sessionId = sessionId;
-        }
-
-        protected override byte[] OnSendBody(byte[] body)
-        {
-            return MemoryZlib.Compress(body, CompressionLevel.SmallestSize);
-        }
-
-        protected override byte[] OnReceiveBody(byte[] body)
-        {
-            if (MemoryZlib.IsCompressed(body))
-            {
-                body = MemoryZlib.Decompress(body);
-            }
-
-            return body;
         }
 
         protected override HttpRequestMessage GetNewRequest(HttpMethod method, string path)

--- a/Fuyu.Launcher.Core/Services/RequestService.cs
+++ b/Fuyu.Launcher.Core/Services/RequestService.cs
@@ -8,22 +8,22 @@ using Fuyu.Backend.Core.Models.Requests;
 using Fuyu.Backend.Core.Models.Responses;
 using Fuyu.Common.Collections;
 using Fuyu.Common.Hashing;
-using Fuyu.Common.Networking;
 using Fuyu.Common.Serialization;
+using Fuyu.Launcher.Core.Networking;
 
 namespace Fuyu.Launcher.Core.Services
 {
     public static class RequestService
     {
-        private static ThreadDictionary<string, HttpClient> _httpClients;
+        private static ThreadDictionary<string, CoreHttpClient> _httpClients;
 
         static RequestService()
         {
-            _httpClients = new ThreadDictionary<string, HttpClient>();
+            _httpClients = new ThreadDictionary<string, CoreHttpClient>();
 
-            _httpClients.Set("fuyu", new EftHttpClient(SettingsService.FuyuAddress, string.Empty));
-            _httpClients.Set("eft", new EftHttpClient(SettingsService.EftAddress, string.Empty));
-            _httpClients.Set("arena", new EftHttpClient(SettingsService.ArenaAddress, string.Empty));
+            _httpClients.Set("fuyu", new CoreHttpClient(SettingsService.FuyuAddress, string.Empty));
+            _httpClients.Set("eft", new CoreHttpClient(SettingsService.EftAddress, string.Empty));
+            _httpClients.Set("arena", new CoreHttpClient(SettingsService.ArenaAddress, string.Empty));
         }
 
         private static void HttpPut<T1>(string id, string path, T1 request)
@@ -58,14 +58,14 @@ namespace Fuyu.Launcher.Core.Services
 
         public static void ResetSessions()
         {
-            _httpClients.Set("fuyu", new EftHttpClient(SettingsService.FuyuAddress, string.Empty));
-            _httpClients.Set("eft", new EftHttpClient(SettingsService.EftAddress, string.Empty));
-            _httpClients.Set("arena", new EftHttpClient(SettingsService.ArenaAddress, string.Empty));
+            _httpClients.Set("fuyu", new CoreHttpClient(SettingsService.FuyuAddress, string.Empty));
+            _httpClients.Set("eft", new CoreHttpClient(SettingsService.EftAddress, string.Empty));
+            _httpClients.Set("arena", new CoreHttpClient(SettingsService.ArenaAddress, string.Empty));
         }
 
         public static void CreateSession(string id, string address, string sessionId)
         {
-            _httpClients.Set(id, new EftHttpClient(address, sessionId));
+            _httpClients.Set(id, new CoreHttpClient(address, sessionId));
         }
 
         public static ERegisterStatus RegisterAccount(string username, string password)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ See `Documentation/CONTRIBUTING.md` for more information on standards.
 ## Requirements
 
 - .NET 8.0 SDK
+- WebView 2 Runtime
 
 ### Supported IDEs
 

--- a/Tests/Fuyu.Tests.Backend.EFT/EndToEnd/BackendTest.cs
+++ b/Tests/Fuyu.Tests.Backend.EFT/EndToEnd/BackendTest.cs
@@ -12,8 +12,8 @@ using Fuyu.Backend.Core.Servers;
 using Fuyu.Backend.EFT;
 using Fuyu.Backend.EFT.Servers;
 using Fuyu.Common.Hashing;
-using Fuyu.Common.Networking;
 using Fuyu.Common.Serialization;
+using Fuyu.Tests.Backend.EFT.Networking;
 using AccountService = Fuyu.Backend.Core.Services.AccountService;
 
 namespace Fuyu.Tests.Backend.EFT.EndToEnd


### PR DESCRIPTION
## Context

Currently all HTTP request go throught the same controllers and contexts. This results in `Fuyu.Backend.Core`, `Fuyu.Backend.EFT` and `Fuyu.Backend.Arena` all using the same request handling.

This is undesirable as `Fuyu.Backend.Core` uses a different way of handling logins than the rest and doesn't need it's requests to be zlibbed. Sharing the same AES key would also be less than ideal. `Fuyu.Backend.Arena` might need to be split off from `Fuyu.Backend.EFT` due to differences in HTTP requests.

## Implementation

- Each backend now has it's own specialized `HttpController` and `HttpContext`. This allows for fine-grained control over the request for each backend.
- `Fuyu.Backend.EFT`'s `/fuyu/game/register` now comminucates over plaintext instead of a zlibbed response.
- `fuyu-debug` header has been changed to `X-Require-Plaintext` to enforce plaintext responses. This will now only work on the server build in debug mode for security reasons.

Other changes include:

- `EftHttpClient` was only used in `Tests.Fuyu.Backend.EFT` and thus moved there.
- `Fuyu.Backend.Core` has been reworked to use a different session system than EFT's.
- Laying the ground work for implementing AES encryption (`X-Encryption` header).
- Additional comments for future work.

## Notes

Initially I wanted to do this through downcasting `HttpContext` into the specialized type (`EftHttpContext` or `CoreHttpContext`) but this wasn't allowed. Neither was I allowed to access  `WebContext.Request` and `WebContext.Response`, which is why I made them public. There probably is a better way of doing this.