### PR TITLE
Workflow format pat

### DIFF
--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -23,6 +23,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
+        token: ${{ secrets.FUYU_WORKFLOWS }}
         ref: ${{ github.head_ref }}
 
     - name: Setup .NET

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Arena    | 0.2.0.32193
 
 1. Github > Generate new PAT
    1. Go [here](https://github.com/settings/tokens/new)
-      - name: `FUYU_WORKFLOWS`
+      - note: `FUYU_WORKFLOWS`
       - permissions: `repo` (all), `workflow` (all)
    2. Once PAT is generated, copy the token to clipboard
 2. Github > Repositories > Fuyu > Settings > Secrets > Actions

--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ See `Documentation/CONTRIBUTING.md` for more information on standards.
 EFT      | 0.15.0.32197
 Arena    | 0.2.0.32193
 
+## Setup
+
+### Local project
+
+1. `git clone https://github.com/project-fika/fuyu`
+2. Visual Studio Code > Terminal > Run Task... > "dotnet: restore"
+
+### Repository CI/CD
+
+1. Github > Generate new PAT
+   1. Go [here](https://github.com/settings/tokens/new)
+      - name: `FUYU_WORKFLOWS`
+      - permissions: `repo` (all), `workflow` (all)
+   2. Once PAT is generated, copy the token to clipboard
+2. Github > Repositories > Fuyu > Settings > Secrets > Actions
+3. New repository secret
+   - name: `FUYU_WORKFLOWS`
+   - field: paste your token
+
 ## Build
 
 Visual Studio Code > Terminal > Run Build Task...


### PR DESCRIPTION
It's a temporarely solution if a better one cannot be found.
The repo now uses github PAT to push the format changes to the dev branch.
Since a privileged PAT is used, it should work with branch protections also.